### PR TITLE
Feat: Traducción de contenido dinámico de colaboradores y corregido u…

### DIFF
--- a/scripts/equipos.js
+++ b/scripts/equipos.js
@@ -44,6 +44,9 @@ document.addEventListener('DOMContentLoaded', () => {
         renderizarEquipos();
         configurarNavegacion();
         
+        if (window.i18n) {
+            window.i18n.updateContent();
+        }
         // Track rendering completion
         if (window.performanceMonitor) {
             window.performanceMonitor.mark('teams-rendered');
@@ -171,10 +174,10 @@ document.addEventListener('DOMContentLoaded', () => {
         section.id = `team-${equipo.id}`;
 
         section.innerHTML = `
-            <h2 class="furality-dept-title">${equipo.nombre}</h2>
+            <h2 class="furality-dept-title" data-i18n="teams.${equipo.id}.name">${equipo.nombre}</h2>
             
             <!-- Descripción del departamento -->
-            <p class="furality-dept-description">${equipo.descripcion}</p>
+            <p class="furality-dept-description" data-i18n="teams.${equipo.id}.description">${equipo.descripcion}</p>
             
             <!-- Líderes del departamento -->
             <div class="furality-leaders">

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -185,7 +185,7 @@ class I18n {
         const metaElements = document.querySelectorAll('[data-i18n-content]');
         metaElements.forEach(element => {
             const key = element.getAttribute('data-i18n-content');
-            const text = this.getTranslatedText(key);
+            const text = this.getText(key);
             if (text) {
                 element.setAttribute('content', text);
             }
@@ -195,7 +195,7 @@ class I18n {
         const titleElements = document.querySelectorAll('title[data-i18n]');
         titleElements.forEach(element => {
             const key = element.getAttribute('data-i18n');
-            const text = this.getTranslatedText(key);
+            const text = this.getText(key);
             if (text) {
                 element.textContent = text;
             }


### PR DESCRIPTION
Este Pull Request implementa la traducción para la página de Colaboradores y además, soluciona un bug crítico en el sistema de internacionalización (i18n.js).

**Problemas Solucionados:**

**Contenido no se traducía:** Al cambiar el idioma a inglés, los nombres y descripciones de los departamentos (ej. "Desarrollo", "Marketing") se quedaban en español. Esto ocurría porque el contenido era generado por equipos.js después de que el script de traducción inicial se ejecutara.

**Bug Crítico en i18n.js:** Descubrí un TypeError que impedía la carga completa de la página en ciertas condiciones. La función updateMetaTags llamaba a this.getTranslatedText(), cuando el nombre correcto de la función es this.getText().
