### PR TITLE
perf: Acelera la carga de la página de colaboradores

### DIFF
--- a/scripts/equipos.js
+++ b/scripts/equipos.js
@@ -5,11 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Aplicar estilo Furality al body
     document.body.classList.add('furality-body');
     
-    // Notificar inmediatamente que los equipos están "listos" para el loading manager
-    // Esto evita que el usuario espere mucho tiempo viendo "Cargando información del equipo..."
-    if (window.onTeamsReady) {
-        window.onTeamsReady();
-    }
 
     // Cargar datos de equipos desde JSON
     async function cargarEquipos() {
@@ -36,17 +31,25 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // Renderizar toda la página
+// Renderizar toda la página
     function renderizarPagina() {
         if (!equiposData) return;
+        
+        const loadingScreen = document.getElementById('loading-screen');
+        if (loadingScreen) {
+            loadingScreen.classList.add('hidden');
+        }
+        document.body.classList.remove('loading');
+        document.body.classList.add('loaded');
+
+        if (window.onTeamsReady) {
+            window.onTeamsReady();
+        }
 
         renderizarNavegacion();
         renderizarEquipos();
         configurarNavegacion();
         
-        if (window.i18n) {
-            window.i18n.updateContent();
-        }
         // Track rendering completion
         if (window.performanceMonitor) {
             window.performanceMonitor.mark('teams-rendered');
@@ -183,10 +186,19 @@ document.addEventListener('DOMContentLoaded', () => {
         container.className = 'furality-container';
         container.innerHTML = '';
 
-        equiposData.equipos.forEach(equipo => {
+        function renderizarSiguienteEquipo(index) {
+            if (index >= equiposData.equipos.length) {
+                if (window.i18n) {
+                    window.i18n.updateContent();
+                }
+                return;
+            }
+            const equipo = equiposData.equipos[index];
             const teamSection = crearSeccionEquipo(equipo);
             container.appendChild(teamSection);
-        });
+            requestAnimationFrame(() => renderizarSiguienteEquipo(index + 1));
+        }
+        renderizarSiguienteEquipo(0);
     }
 
     // Crear sección individual de equipo estilo Furality


### PR DESCRIPTION
Este PR soluciona el largo tiempo de carga (3-5 segundos) que tenía la página de colaboradores.

**Problema:**
La pantalla de carga se quedaba "pegada" mucho después de que los datos ya se habían cargado, resultando en una pantalla de carga de 5 segundos

**Solución:**
He modificado el script equipos.js para que tome el control directo del proceso de carga:

Oculta la pantalla de carga en cuanto los datos están listos.
Hace visible el contenido de la página inmediatamente.
Renderiza la lista de colaboradores de forma progresiva.